### PR TITLE
Remove deprecated import

### DIFF
--- a/subs.py
+++ b/subs.py
@@ -1,13 +1,13 @@
-import urllib.request
+import urllib
 import json
 import time
 
 key = "/*get the api key by google*/"
 
-datapewds = urllib.request.urlopen("https://www.googleapis.com/youtube/v3/channels?part=statistics&forUsername="+"pewdiepie"+"&key="+key).read()
+datapewds = urllib.urlopen("https://www.googleapis.com/youtube/v3/channels?part=statistics&forUsername="+"pewdiepie"+"&key="+key).read()
 subspewds = int(json.loads(datapewds.decode('utf-8'))["items"][0]["statistics"]["subscriberCount"])
 
-datatseries = urllib.request.urlopen("https://www.googleapis.com/youtube/v3/channels?part=statistics&forUsername="+"tseries"+"&key="+key).read()
+datatseries = urllib.urlopen("https://www.googleapis.com/youtube/v3/channels?part=statistics&forUsername="+"tseries"+"&key="+key).read()
 substseries = int(json.loads(datatseries.decode('utf-8'))["items"][0]["statistics"]["subscriberCount"])
 
 diff = subspewds-substseries


### PR DESCRIPTION
Urllib.request appears to be deprecated, you should use urllib instead. On a fresh install the original code wouldn't run even with urllib installed, this code does.